### PR TITLE
fix: return exit 0 after error log, to unlock the initContainer lock,…

### DIFF
--- a/dataFeeder/src/index-job.mjs
+++ b/dataFeeder/src/index-job.mjs
@@ -70,5 +70,5 @@ try {
   process.exit(0);
 } catch (error) {
   console.log(error);
-  process.exit(1);
+  process.exit(0);
 }


### PR DESCRIPTION
… on k8s deploy